### PR TITLE
Potential fix for code scanning alert no. 1: DOM text reinterpreted as HTML

### DIFF
--- a/frontend/components/profile/UpdateInfoDialog.jsx
+++ b/frontend/components/profile/UpdateInfoDialog.jsx
@@ -1,6 +1,15 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+
+function sanitizeAvatar(avatar) {
+  const dataUrlPattern = /^data:image\/(png|jpeg|jpg|gif|webp);base64,/;
+  const safeUrlPattern = /^https?:\/\/[^\s/$.?#].[^\s]*$/i;
+  if (dataUrlPattern.test(avatar) || safeUrlPattern.test(avatar)) {
+    return avatar;
+ }
+ return null;
+}
 import { validateForm } from '@/lib/validateUserInfo';
 import Toast from '../toast/Toast';
 export default function UpdateInfoDialog({ user, onClose, setProfile, cookieValue }) {
@@ -92,7 +101,7 @@ export default function UpdateInfoDialog({ user, onClose, setProfile, cookieValu
     <div className="dialog-overlay">
       <div className="profile-dialog-content">
         <label htmlFor="avatar-upload" className="avatar-container">
-          <img src={formData.avatar || '/default-avatar.jpg'} alt="Avatar" className="avatar-update" />
+          <img src={sanitizeAvatar(formData.avatar) || '/default-avatar.jpg'} alt="Avatar" className="avatar-update" />
         </label>
         <input type="file" id="avatar-upload" accept="image/*" onChange={handleAvatarChange} />
 


### PR DESCRIPTION
Potential fix for [https://github.com/Hamza-El-Azzouzi/blank/security/code-scanning/1](https://github.com/Hamza-El-Azzouzi/blank/security/code-scanning/1)

To fix the issue, we need to ensure that the `formData.avatar` value is sanitized before being used in the `src` attribute of the `<img>` tag. Since the `avatar` value is expected to be a data URL or a safe default image path, we can validate it to ensure it matches the expected format. If the value is invalid, we can fall back to the default avatar image.

1. Add a utility function to validate the `avatar` value. This function will check if the value is a valid data URL or a safe URL.
2. Use this utility function to sanitize the `formData.avatar` value before rendering it in the `src` attribute of the `<img>` tag.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
